### PR TITLE
Update requirements.txt to enable git clone via https

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
--e git://github.com/boto/botocore.git@develop#egg=botocore
--e git://github.com/boto/jmespath.git@develop#egg=jmespath
+-e git+https://github.com/boto/botocore.git@develop#egg=botocore
+-e git+https://github.com/boto/jmespath.git@develop#egg=jmespath
 nose==1.3.3
 mock==1.3.0
 wheel==0.24.0


### PR DESCRIPTION
Behind some corporate firewalls it is not possible to use the git protocol to clone git repositories. So https has been added as alternative protocol to clone git repositories.